### PR TITLE
chore: 🔧 update Node.js version requirements in configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "nodejs.docs.sendlix.com",
   "engines": {
-    "node": ">=16.20.2"
+    "node": ">=18.0.0"
   },
   "keywords": [
     "sendlix",


### PR DESCRIPTION
* Updated the Node.js versions in the CI configuration to include `24.x`.
* Adjusted the minimum required Node.js version in `package.json` to `>=18.0.0`.